### PR TITLE
Add code highlighting, TOC, anchors and copy buttons

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -27,15 +27,18 @@ async def read_post(name: str, request: Request):
 
     if file_path.suffix == ".md":
         content = file_path.read_text(encoding="utf-8")
-        body = markdown.markdown(content)
+        md = markdown.Markdown(extensions=["fenced_code", "codehilite", "toc"])
+        body = md.convert(content)
+        toc = md.toc
     elif file_path.suffix == ".ipynb":
         nb = nbformat.read(file_path, as_version=4)
         html_exporter = HTMLExporter()
         body, _ = html_exporter.from_notebook_node(nb)
+        toc = ""
     else:
         raise HTTPException(status_code=400, detail="Unsupported file type")
 
-    return templates.TemplateResponse("post.html", {"request": request, "content": body})
+    return templates.TemplateResponse("post.html", {"request": request, "content": body, "toc": toc})
 
 
 @app.get("/admin/login", response_class=HTMLResponse)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>{{ title if title else "Blog" }}</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
 </head>
 <body>
     <nav>

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -1,4 +1,62 @@
 {% extends "base.html" %}
 {% block content %}
-<div>{{ content|safe }}</div>
+<div class="toc">{{ toc|safe }}</div>
+<div class="post-body">{{ content|safe }}</div>
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  hljs.highlightAll();
+
+  document.querySelectorAll('pre').forEach(function(pre) {
+    var button = document.createElement('button');
+    button.innerText = 'Copy';
+    button.className = 'copy-button';
+    pre.style.position = 'relative';
+    button.style.position = 'absolute';
+    button.style.top = '4px';
+    button.style.right = '4px';
+    button.addEventListener('click', function() {
+      navigator.clipboard.writeText(pre.innerText).then(function() {
+        button.innerText = 'Copied!';
+        setTimeout(function() { button.innerText = 'Copy'; }, 2000);
+      });
+    });
+    pre.appendChild(button);
+  });
+
+  document.querySelectorAll('.post-body h1, .post-body h2, .post-body h3, .post-body h4, .post-body h5, .post-body h6').forEach(function(h) {
+    if (h.id) {
+      var anchor = document.createElement('a');
+      anchor.href = '#' + h.id;
+      anchor.textContent = '#';
+      anchor.className = 'anchor-link';
+      h.appendChild(anchor);
+    }
+  });
+});
+</script>
+<style>
+.copy-button {
+    font-size: 0.8em;
+    padding: 2px 6px;
+}
+.anchor-link {
+    margin-left: 0.5em;
+    text-decoration: none;
+    color: #000;
+    visibility: hidden;
+}
+.post-body h1:hover .anchor-link,
+.post-body h2:hover .anchor-link,
+.post-body h3:hover .anchor-link,
+.post-body h4:hover .anchor-link,
+.post-body h5:hover .anchor-link,
+.post-body h6:hover .anchor-link {
+    visibility: visible;
+}
+.toc {
+    border: 1px solid #ccc;
+    padding: 1em;
+    margin-bottom: 1em;
+}
+</style>
 {% endblock %}

--- a/posts/sample.ipynb
+++ b/posts/sample.ipynb
@@ -2,10 +2,102 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "ef3f97a6",
    "metadata": {},
    "source": [
     "# Sample Notebook\n",
-    "This is a sample notebook."
+    "This notebook showcases multiple features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebeaac08",
+   "metadata": {},
+   "source": [
+    "## Fibonacci Sequence\n",
+    "Generate Fibonacci numbers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c3eae22b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def fib(n):\n",
+    "    a, b = 0, 1\n",
+    "    seq = []\n",
+    "    while len(seq) < n:\n",
+    "        seq.append(a)\n",
+    "        a, b = b, a + b\n",
+    "    return seq\n",
+    "\n",
+    "fib(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1e7491d",
+   "metadata": {},
+   "source": [
+    "## Factorial Function\n",
+    "Let's compute factorials for a few numbers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cdd02ea1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 1, 2, 6, 24, 120]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def factorial(n):\n",
+    "    if n == 0:\n",
+    "        return 1\n",
+    "    return n * factorial(n-1)\n",
+    "\n",
+    "[factorial(i) for i in range(6)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cb78ce1",
+   "metadata": {},
+   "source": [
+    "## Lists and Code Blocks\n",
+    "- Fruits\n",
+    "  - Apple\n",
+    "  - Banana\n",
+    "- Vegetables\n",
+    "  - Carrot\n",
+    "\n",
+    "```python\n",
+    "for i in range(3):\n",
+    "    print(i)\n",
+    "```"
    ]
   }
  ],

--- a/posts/sample.md
+++ b/posts/sample.md
@@ -1,3 +1,40 @@
 # Sample Post
 
-This is a sample markdown post.
+A more complex markdown file to showcase blog features.
+
+## Introduction
+
+Welcome to the sample post. This section introduces the document.
+
+## Lists
+
+- Item one
+- Item two
+  - Sub item
+  - Sub item
+
+## Code Blocks
+
+### Python
+
+```python
+def fibonacci(n):
+    if n <= 1:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
+print([fibonacci(i) for i in range(10)])
+```
+
+### JavaScript
+
+```javascript
+function greet(name) {
+  console.log(`Hello ${name}`);
+}
+greet('World');
+```
+
+## Conclusion
+
+This marks the end of the demo post.


### PR DESCRIPTION
## Summary
- Render markdown posts with fenced code, syntax highlighting, and auto-generated table of contents
- Load highlight.js to style code blocks and support client-side features
- Enhance post template with TOC display, copy buttons for code, and anchor links for headings
- Expand demo markdown post with multiple sections and code blocks to exercise new features
- Enrich sample Jupyter notebook with Fibonacci and factorial examples plus nested lists and a code block for thorough testing

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57a22db508327a8f167208299b08f