### PR TITLE
feat: add tag archive and search

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -57,6 +57,7 @@
 <body>
     <nav>
         <a href="/">Home</a>
+        <a href="/tags">Tags</a>
         {% if request.session.get('user') %}
         <a href="/admin/upload">Upload</a>
         <a href="/admin/posts">Posts</a>
@@ -64,6 +65,10 @@
         {% else %}
         <a href="/admin/login">Login</a>
         {% endif %}
+        <form action="/search" method="get" style="margin-left:auto;">
+            <input type="text" name="q" placeholder="Search">
+            <button type="submit">Go</button>
+        </form>
         <button id="theme-toggle" type="button">Toggle Theme</button>
     </nav>
     <hr>

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -2,7 +2,13 @@
 {% block content %}
 <div class="toc">{{ toc|safe }}</div>
 {% if category %}<p>Category: {{ category }}</p>{% endif %}
-{% if tags %}<p>Tags: {{ tags | join(', ') }}</p>{% endif %}
+{% if tags %}
+<p>Tags:
+{% for tag in tags %}
+    <a href="/tags/{{ tag }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+{% endfor %}
+</p>
+{% endif %}
 <div class="post-body">{{ content|safe }}</div>
 <script>
 document.addEventListener("DOMContentLoaded", function() {

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Search Results for "{{ query }}"</h1>
+<ul>
+{% for post in results %}
+  <li><a href="/post/{{ post }}">{{ post }}</a></li>
+{% else %}
+  <li>No results found.</li>
+{% endfor %}
+</ul>
+{% endblock %}
+

--- a/app/templates/tag.html
+++ b/app/templates/tag.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Tag: {{ tag }}</h1>
+<ul>
+{% for post in posts %}
+  <li><a href="/post/{{ post }}">{{ post }}</a></li>
+{% else %}
+  <li>No posts with this tag.</li>
+{% endfor %}
+</ul>
+{% endblock %}
+

--- a/app/templates/tags.html
+++ b/app/templates/tags.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Tags</h1>
+<ul>
+{% for tag, posts in tags.items() %}
+  <li><a href="/tags/{{ tag }}">{{ tag }}</a> ({{ posts|length }})</li>
+{% else %}
+  <li>No tags found.</li>
+{% endfor %}
+</ul>
+{% endblock %}
+

--- a/posts/sample.md
+++ b/posts/sample.md
@@ -1,3 +1,6 @@
+tags: demo, sample
+category: examples
+
 # Sample Post
 
 A more complex markdown file to showcase blog features.


### PR DESCRIPTION
## Summary
- add tag listing and tag-specific pages
- implement simple text-based site search
- expose navigation links and tag metadata

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a58c86ed2c8327a06556172b6b281b